### PR TITLE
CI scripts to exclude devDependencies from Lambda

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,12 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    - run: ./build.sh okta_native
-    - run: test -f distributions/okta_native/okta_native.zip
-    - run: ./build.sh rotate_key_pair
-    - run: test -f distributions/rotate_key_pair/rotate_key_pair.zip
+    - run: npm run-script test-ci
 
-    - run: npm run-script mocha
+    - run: npm run-script build-ci okta_native
+    - run: test -f distributions/okta_native/okta_native.zip
+    - run: npm run-script build-ci rotate_key_pair
+    - run: test -f distributions/rotate_key_pair/rotate_key_pair.zip
 
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,13 +21,13 @@ jobs:
         with:
           node-version: '10.x'
 
-      - name: Build okta_native
-        run: ./build.sh okta_native
-      - name: Build rotate_key_pair
-        run: ./build.sh rotate_key_pair
+      - name: Run tests
+        run: npm run-script test-ci
 
-      - name: Run Mocha tests
-        run: npm run-script mocha
+      - name: Build okta_native
+        run: npm run-script build-ci okta_native
+      - name: Build rotate_key_pair
+        run: npm run-script build-ci rotate_key_pair
 
       - name: Create Release
         id: create_release

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "cd tests && npm install && cd .. && node tests/tests.js",
-    "mocha": "mocha './mocha/*.js'",
-    "build": "npm install && cd build && npm install && cd .. && node build/build.js"
+    "test-ci": "npm ci && mocha './mocha/*.js'",
+    "build": "npm install && cd build && npm install && cd .. && node build/build.js",
+    "build-ci": "npm ci --production && cd build && npm ci --production && cd .. && node build/build.js"
   },
   "author": "Widen Enterprises",
   "repository": "github:widen/cloudfront-auth",


### PR DESCRIPTION
devDependencies in node_modules caused the package size to exceed the limit for Lambda functions that are triggered by CloudFront