### PR TITLE
Add generic Google handlers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ jobs:
 
     - run: npm run-script build-ci okta_native
     - run: test -f distributions/okta_native/okta_native.zip
+    - run: npm run-script build-ci google hosted-domain
+    - run: test -f distributions/google/google-hosted_domain.zip
+    - run: npm run-script build-ci google email-lookup
+    - run: test -f distributions/google/google-email_lookup.zip
     - run: npm run-script build-ci rotate_key_pair
     - run: test -f distributions/rotate_key_pair/rotate_key_pair.zip
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,10 @@ jobs:
 
       - name: Build okta_native
         run: npm run-script build-ci okta_native
+      - name: Build google-hosted_domain
+        run: npm run-script build-ci google hosted-domain
+      - name: Build google-email_lookup
+        run: npm run-script build-ci google email-lookup
       - name: Build rotate_key_pair
         run: npm run-script build-ci rotate_key_pair
 
@@ -48,6 +52,24 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./distributions/okta_native/okta_native.zip
           asset_name: okta_native_${{ steps.get_variables.outputs.tag_name }}.zip
+          asset_content_type: application/zip
+      - name: Upload google-hosted_domain
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./distributions/google/google-hosted_domain.zip
+          asset_name: google-hosted_domain_${{ steps.get_variables.outputs.tag_name }}.zip
+          asset_content_type: application/zip
+      - name: Upload google-email-lookup
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./distributions/google/google-email_lookup.zip
+          asset_name: google-email_lookup_${{ steps.get_variables.outputs.tag_name }}.zip
           asset_content_type: application/zip
       - name: Upload rotate_key_pair
         uses: actions/upload-release-asset@v1

--- a/config/generic.config.js
+++ b/config/generic.config.js
@@ -11,7 +11,7 @@ module.exports.getConfig = function (fileName, functionName, callback) {
 
   // Get parameters from SSM Parameter Store
   const ssm = new aws.SSM({ region: 'us-east-1' });
-  const getParametersByPathPromise = ssm.getParametersByPath({ Path: `/${name}` }).promise();
+  const getParametersByPathPromise = ssm.getParametersByPath({ Path: `/${name}`, WithDecryption: true }).promise();
 
   // Get key pair from Secrets Manager
   const secretsmanager = new aws.SecretsManager({ region: 'us-east-1' });


### PR DESCRIPTION
@iress given your PR is still pending, perhaps it'd be worth adding my Google update to it (feedback welcome)

This commit extends the generic package support to include Google
authenticators

It generates separate packages for "hosted-domain" and "email-lookup"
validation types, but does not yet include one for "google-groups" as
that requires a JSON file at runtime; need to determine a good option to
supply that as a secret.