### PR TITLE
use the access token kid to pick up the signing key

### DIFF
--- a/authn/pkce.index.js
+++ b/authn/pkce.index.js
@@ -130,12 +130,14 @@ function mainProcess(event, context, callback) {
       .then(function(response) {
         console.log(response);
         const decodedData = jwt.decode(response.data.id_token, {complete: true});
-        console.log(decodedData);
+        const decodedAccessTokenData = jwt.decode(response.data.access_token, {complete: true});
+        console.log("Decoded id_token: ", decodedData);
+        console.log("Decoded access_token", decodedAccessTokenData);
         try {
           console.log("Searching for JWK from discovery document");
 
           // Search for correct JWK from discovery document and create PEM
-          var pem = createPEM(decodedData.header.kid);
+          var pem = createPEM(decodedAccessTokenData.header.kid); //We are verifying the access token
 
           console.log("Verifying JWT");
           const access_token = response.data.access_token;


### PR DESCRIPTION
Use the access token associated KID when verifying the access token JWT. Wired in some logging for debugging but will tidy up in future PR's