### PR TITLE
Encrypt sec manager secret cmk

### DIFF
--- a/infra/terraform/modules/_auth/main.tf
+++ b/infra/terraform/modules/_auth/main.tf
@@ -30,6 +30,7 @@ module "auth" {
   timeout                  = 5
   iam_policy_override_json = data.aws_iam_policy_document.auth.json
   lambda_at_edge           = true
+  kms_key_arn              = var.kms_key_arn
 }
 
 module "rotation" {
@@ -40,6 +41,7 @@ module "rotation" {
   package_url              = "https://github.com/iress/cloudfront-auth/releases/download/${var.release_version}/rotate_key_pair.zip"
   timeout                  = 30
   iam_policy_override_json = data.aws_iam_policy_document.rotation.json
+  kms_key_arn              = var.kms_key_arn
 }
 
 resource "aws_lambda_permission" "allow_secrets_manager" {

--- a/infra/terraform/modules/_auth/secrets.tf
+++ b/infra/terraform/modules/_auth/secrets.tf
@@ -2,6 +2,7 @@ resource "aws_secretsmanager_secret" "key_pair" {
   name                    = "${var.name}/key-pair"
   recovery_window_in_days = 0
   tags                    = var.tags
+  kms_key_id              = var.kms_key_arn
 }
 
 resource "aws_secretsmanager_secret_rotation" "key_pair" {

--- a/infra/terraform/modules/_auth/variables.tf
+++ b/infra/terraform/modules/_auth/variables.tf
@@ -22,3 +22,9 @@ variable "key_pair_rotation_period_days" {
   description = "The number of days between automatic scheduled rotations of the key pair"
   type        = number
 }
+
+variable "kms_key_arn" {
+  description = "kms key to encrypt secrets manager secret"
+  type        = string
+  default     = null
+}

--- a/infra/terraform/modules/_auth/variables.tf
+++ b/infra/terraform/modules/_auth/variables.tf
@@ -24,7 +24,7 @@ variable "key_pair_rotation_period_days" {
 }
 
 variable "kms_key_arn" {
-  description = "kms key to encrypt secrets manager secret"
+  description = "The ARN of the KMS key used to encrypt the key pair"
   type        = string
   default     = null
 }

--- a/infra/terraform/modules/_lambda/iam.tf
+++ b/infra/terraform/modules/_lambda/iam.tf
@@ -1,3 +1,7 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
 data "aws_iam_policy_document" "assume_role" {
   statement {
     actions = ["sts:AssumeRole"]
@@ -22,6 +26,14 @@ data "aws_iam_policy_document" "execution" {
     ]
 
     resources = ["arn:aws:logs:*:*:*"]
+  }
+
+  dynamic "statement" {
+    for_each = var.kms_key_arn != null ? [var.kms_key_arn] : []
+    content {
+      actions   = ["kms:Decrypt","kms:GenerateDataKey"]
+      resources = [ statement.value ]
+    }
   }
 }
 

--- a/infra/terraform/modules/_lambda/variables.tf
+++ b/infra/terraform/modules/_lambda/variables.tf
@@ -30,3 +30,9 @@ variable "lambda_at_edge" {
   type        = bool
   default     = false
 }
+
+variable "kms_key_arn" {
+  description = "kms key to encrypt secrets manager secret"
+  type        = string
+  default     = null
+}

--- a/infra/terraform/modules/_lambda/variables.tf
+++ b/infra/terraform/modules/_lambda/variables.tf
@@ -32,7 +32,7 @@ variable "lambda_at_edge" {
 }
 
 variable "kms_key_arn" {
-  description = "kms key to encrypt secrets manager secret"
+  description = "The ARN of the KMS key used to encrypt the key pair"
   type        = string
   default     = null
 }

--- a/infra/terraform/modules/okta_native/main.tf
+++ b/infra/terraform/modules/okta_native/main.tf
@@ -6,4 +6,5 @@ module "auth" {
   tags                          = var.tags
   package_url                   = "https://github.com/iress/cloudfront-auth/releases/download/${var.release_version}/okta_native.zip"
   key_pair_rotation_period_days = var.key_pair_rotation_period_days
+  kms_key_arn                   = var.kms_key_arn
 }

--- a/infra/terraform/modules/okta_native/variables.tf
+++ b/infra/terraform/modules/okta_native/variables.tf
@@ -60,7 +60,7 @@ variable "scope" {
 }
 
 variable "kms_key_arn" {
-  description = "kms key to encrypt secrets manager secret"
+  description = "The ARN of the KMS key used to encrypt the key pair"
   type        = string
   default     = null
 }

--- a/infra/terraform/modules/okta_native/variables.tf
+++ b/infra/terraform/modules/okta_native/variables.tf
@@ -58,3 +58,9 @@ variable "scope" {
   type        = string
   default     = "openid email"
 }
+
+variable "kms_key_arn" {
+  description = "kms key to encrypt secrets manager secret"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
Checkov requires secret manager secrets to be encrypted with a CMK.
Functionality added to do this. The key is optional, so if the `kms_key_arn` is not passed when calling the okta_native module, the AWS `DefaultEncryptionKey` is used to encrypt the key pair