### PR TITLE
Updating openId to support subdirectories by updating the URI on the …

### DIFF
--- a/authn/openid.index.js
+++ b/authn/openid.index.js
@@ -55,7 +55,13 @@ exports.handler = (event, context, callback) => {
 function mainProcess(event, context, callback) {
 
   // Get request, request headers, and querystring dictionary
-  const request = event.Records[0].cf.request;
+  var request = event.Records[0].cf.request;
+
+  // Updating Uri with index.html to support subdirectories on CF
+  var receivedUri = request.uri;
+  var updatedUri = receivedUri.replace(/\/$/, '\/index.html'); 
+  request.uri = updatedUri;
+  
   const headers = request.headers;
   const queryDict = qs.parse(request.querystring);
   if (event.Records[0].cf.config.hasOwnProperty('test')) {


### PR DESCRIPTION
CloudFront does not support static subdirectories by default, on parallel to the Auth0, is necessary to dynamically update the URI request to include 'index.html' (or the corresponding file) to support it.

More info: https://aws.amazon.com/es/blogs/compute/implementing-default-directory-indexes-in-amazon-s3-backed-amazon-cloudfront-origins-using-lambdaedge/