### PR TITLE
remove max version constraint on provider

### DIFF
--- a/infra/terraform/modules/_auth/provider.tf
+++ b/infra/terraform/modules/_auth/provider.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3"
+      version = ">= 3"
     }
   }
 }

--- a/infra/terraform/modules/_lambda/provider.tf
+++ b/infra/terraform/modules/_lambda/provider.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3"
+      version = ">= 3"
     }
   }
 }

--- a/infra/terraform/modules/okta_native/provider.tf
+++ b/infra/terraform/modules/okta_native/provider.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3"
+      version = ">= 3"
     }
   }
 }


### PR DESCRIPTION
This PR removes the max version constraint on the aws Terraform provider so consuming modules can be upgraded to the v4 Terraform provider. 
Based on the Terraform upgrade [docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade) there should be no issues using the current infra in the repo with the v4 provider