### PR TITLE
Ensure permissions are deployed before the secret rotation is applied

### DIFF
--- a/infra/terraform/modules/_auth/secrets.tf
+++ b/infra/terraform/modules/_auth/secrets.tf
@@ -12,4 +12,9 @@ resource "aws_secretsmanager_secret_rotation" "key_pair" {
   rotation_rules {
     automatically_after_days = var.key_pair_rotation_period_days
   }
+  
+  # Secrets manager requires the access to the rotation lambda to be applied
+  depends_on = [
+    aws_lambda_permission.allow_secrets_manager
+  ]
 }


### PR DESCRIPTION
This PR aims to fix a bug where if you deploy the components one by one with `parallelism=1`, deploying the secret rotation fails because of a lack of permission to call the rotation lambda.