### PR TITLE
fix: Migrate away from 'override_json' which is deprecated in AWS Pro…

### DIFF
--- a/infra/terraform/modules/_auth/provider.tf
+++ b/infra/terraform/modules/_auth/provider.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3"
+      version = ">= 3.28"
     }
   }
 }

--- a/infra/terraform/modules/_lambda/iam.tf
+++ b/infra/terraform/modules/_lambda/iam.tf
@@ -14,7 +14,9 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 data "aws_iam_policy_document" "execution" {
-  override_json = var.iam_policy_override_json
+  override_policy_documents = var.iam_policy_override_json == null ? [] : [
+    var.iam_policy_override_json
+  ]
 
   statement {
     sid = "logs"

--- a/infra/terraform/modules/_lambda/provider.tf
+++ b/infra/terraform/modules/_lambda/provider.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3"
+      version = ">= 3.28"
     }
   }
 }

--- a/infra/terraform/modules/okta_native/provider.tf
+++ b/infra/terraform/modules/okta_native/provider.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3"
+      version = ">= 3.28"
     }
   }
 }


### PR DESCRIPTION
…vider V4

- NOTE: 'override_policy_documents' is available since 3.28.0