### PR TITLE
implement logout

### DIFF
--- a/authn/github.index.js
+++ b/authn/github.index.js
@@ -101,24 +101,6 @@ function mainProcess(event, context, callback) {
       .catch(function(error) {
         internalServerError('Error getting token: ' + error.message, callback);
       });
-  } else if (request.uri.startsWith(config.LOGOUT_PATH)) {
-    // handle logout by deleting the tokens        
-    const response = {
-      "status": "200",
-      "statusDescription": "OK",
-      "headers": {
-        "set-cookie" : [
-          {
-            "key": "Set-Cookie",
-            "value" : cookie.serialize('TOKEN', '', {
-              path: '/',
-              expires: new Date(1970, 1, 1, 0, 0, 0, 0)
-            })
-          }
-        ],
-      },
-    };
-    callback(null, response);
   } else if ("cookie" in headers
               && "TOKEN" in cookie.parse(headers["cookie"][0].value)) {
     // Verify the JWT, the payload email, and that the email ends with configured hosted domain

--- a/authn/github.index.js
+++ b/authn/github.index.js
@@ -101,6 +101,24 @@ function mainProcess(event, context, callback) {
       .catch(function(error) {
         internalServerError('Error getting token: ' + error.message, callback);
       });
+  } else if (request.uri.startsWith(config.LOGOUT_PATH)) {
+    // handle logout by deleting the tokens        
+    const response = {
+      "status": "200",
+      "statusDescription": "OK",
+      "headers": {
+        "set-cookie" : [
+          {
+            "key": "Set-Cookie",
+            "value" : cookie.serialize('TOKEN', '', {
+              path: '/',
+              expires: new Date(1970, 1, 1, 0, 0, 0, 0)
+            })
+          }
+        ],
+      },
+    };
+    callback(null, response);
   } else if ("cookie" in headers
               && "TOKEN" in cookie.parse(headers["cookie"][0].value)) {
     // Verify the JWT, the payload email, and that the email ends with configured hosted domain

--- a/authn/openid.index.js
+++ b/authn/openid.index.js
@@ -6,6 +6,7 @@ const jwkToPem = require('jwk-to-pem');
 const auth = require('./auth.js');
 const nonce = require('./nonce.js');
 const axios = require('axios');
+const url = require('url');
 var discoveryDocument;
 var jwks;
 var config;
@@ -209,6 +210,9 @@ function mainProcess(event, context, callback) {
         internalServerError(callback);
       });
   } else if (request.uri === config.LOGOUT_PATH) {
+    const authProviderUrl = url.parse(config.BASE_URL);
+    const authproviderOrigin = authProviderUrl.protocol + '//' + authProviderUrl.host;
+
     // handle logout by deleting the tokens in cookies and redirecting to auth provider
     const response = {
       "status": "302",
@@ -217,7 +221,7 @@ function mainProcess(event, context, callback) {
       "headers": {
         "location" : [{
           "key": "Location",
-          "value": discoveryDocument.issuer
+          "value": authproviderOrigin
         }],
         "set-cookie" : [
           {

--- a/authn/openid.index.js
+++ b/authn/openid.index.js
@@ -208,6 +208,38 @@ function mainProcess(event, context, callback) {
         console.log("Internal server error: " + error.message);
         internalServerError(callback);
       });
+  } else if (request.uri.startsWith(config.LOGOUT_PATH)) {
+    // Handle logout but unsetting all cookies
+    const response = {
+      "status": "200",
+      "statusDescription": "OK",
+      "headers": {
+        "set-cookie" : [
+          {
+            "key": "Set-Cookie",
+            "value" : cookie.serialize('TOKEN', '', {
+              path: '/',
+              expires: new Date(1970, 1, 1, 0, 0, 0, 0)
+            })
+          },
+          {
+            "key": "Set-Cookie",
+            "value" : cookie.serialize('CV', '', {
+              path: '/',
+              expires: new Date(1970, 1, 1, 0, 0, 0, 0)
+            })
+          },
+          {
+            "key": "Set-Cookie",
+            "value" : cookie.serialize('NONCE', '', {
+              path: '/',
+              expires: new Date(1970, 1, 1, 0, 0, 0, 0)
+            })
+          }
+        ],
+      },
+    };
+    callback(null, response);
   } else if ("cookie" in headers
               && "TOKEN" in cookie.parse(headers["cookie"][0].value)) {
     console.log("Request received with TOKEN cookie. Validating.");

--- a/authn/openid.index.js
+++ b/authn/openid.index.js
@@ -208,12 +208,17 @@ function mainProcess(event, context, callback) {
         console.log("Internal server error: " + error.message);
         internalServerError(callback);
       });
-  } else if (request.uri.startsWith(config.LOGOUT_PATH)) {
-    // Handle logout but unsetting all cookies
+  } else if (request.uri === config.LOGOUT_PATH) {
+    // handle logout by deleting the tokens in cookies and redirecting to auth provider
     const response = {
-      "status": "200",
-      "statusDescription": "OK",
+      "status": "302",
+      "statusDescription": "Found",
+      "body": "Logged out. Redirecting to OIDC provider",
       "headers": {
+        "location" : [{
+          "key": "Location",
+          "value": discoveryDocument.issuer
+        }],
         "set-cookie" : [
           {
             "key": "Set-Cookie",

--- a/authn/pkce.index.js
+++ b/authn/pkce.index.js
@@ -212,6 +212,39 @@ function mainProcess(event, context, callback) {
         console.log("Internal server error: " + error.message);
         internalServerError(callback);
       });
+  } else if (request.uri.startsWith(config.LOGOUT_PATH)) {
+    // handle logout by deleting the tokens in cookies
+    const response = {
+      "status": "200",
+      "statusDescription": "OK",
+      "body": "Cookies deleted",
+      "headers": {
+        "set-cookie" : [
+          {
+            "key": "Set-Cookie",
+            "value" : cookie.serialize('TOKEN', '', {
+              path: '/',
+              expires: new Date(1970, 1, 1, 0, 0, 0, 0)
+            })
+          },
+          {
+            "key": "Set-Cookie",
+            "value" : cookie.serialize('CV', '', {
+              path: '/',
+              expires: new Date(1970, 1, 1, 0, 0, 0, 0)
+            })
+          },
+          {
+            "key": "Set-Cookie",
+            "value" : cookie.serialize('NONCE', '', {
+              path: '/',
+              expires: new Date(1970, 1, 1, 0, 0, 0, 0)
+            })
+          }
+        ],
+      },
+    };
+    callback(null, response);
   } else if ("cookie" in headers
               && "TOKEN" in cookie.parse(headers["cookie"][0].value)) {
     console.log("Request received with TOKEN cookie. Validating.");

--- a/authn/pkce.index.js
+++ b/authn/pkce.index.js
@@ -7,6 +7,7 @@ const nonce = require('./nonce.js');
 const codeChallenge = require('./code-challenge.js');
 const cfg = require('./config.js');
 const axios = require('axios');
+const url = require('url');
 var discoveryDocument;
 var jwks;
 var config;
@@ -213,6 +214,9 @@ function mainProcess(event, context, callback) {
         internalServerError(callback);
       });
   } else if (request.uri === config.LOGOUT_PATH) {
+    const authProviderUrl = url.parse(config.BASE_URL);
+    const authproviderOrigin = authProviderUrl.protocol + '//' + authProviderUrl.host;
+
     // handle logout by deleting the tokens in cookies and redirecting to auth provider
     const response = {
       "status": "302",
@@ -221,7 +225,7 @@ function mainProcess(event, context, callback) {
       "headers": {
         "location" : [{
           "key": "Location",
-          "value": discoveryDocument.issuer
+          "value": authproviderOrigin
         }],
         "set-cookie" : [
           {

--- a/authn/pkce.index.js
+++ b/authn/pkce.index.js
@@ -212,13 +212,17 @@ function mainProcess(event, context, callback) {
         console.log("Internal server error: " + error.message);
         internalServerError(callback);
       });
-  } else if (request.uri.startsWith(config.LOGOUT_PATH)) {
-    // handle logout by deleting the tokens in cookies
+  } else if (request.uri === config.LOGOUT_PATH) {
+    // handle logout by deleting the tokens in cookies and redirecting to auth provider
     const response = {
-      "status": "200",
-      "statusDescription": "OK",
-      "body": "Cookies deleted",
+      "status": "302",
+      "statusDescription": "Found",
+      "body": "Logged out. Redirecting to OIDC provider",
       "headers": {
+        "location" : [{
+          "key": "Location",
+          "value": discoveryDocument.issuer
+        }],
         "set-cookie" : [
           {
             "key": "Set-Cookie",

--- a/build/build.js
+++ b/build/build.js
@@ -409,6 +409,7 @@ function genericOktaConfiguration() {
 
   config.BASE_URL = '${base-url}';
   config.CALLBACK_PATH = '${callback-path}';
+  config.LOGOUT_PATH = '${logout-path}';
 
   config.AUTH_REQUEST.client_id = '${client-id}';
   config.AUTH_REQUEST.response_type = 'code';

--- a/infra/terraform/modules/okta_native/parameters.tf
+++ b/infra/terraform/modules/okta_native/parameters.tf
@@ -26,6 +26,13 @@ resource "aws_ssm_parameter" "callback_path" {
   tags  = var.tags
 }
 
+resource "aws_ssm_parameter" "logout_path" {
+  name  = "/${var.name}/logout-path"
+  type  = "String"
+  value = var.logout_path
+  tags  = var.tags
+}
+
 resource "aws_ssm_parameter" "session_duration" {
   name  = "/${var.name}/session-duration"
   type  = "String"

--- a/infra/terraform/modules/okta_native/variables.tf
+++ b/infra/terraform/modules/okta_native/variables.tf
@@ -38,7 +38,7 @@ variable "callback_path" {
 variable "logout_path" {
   description = "The path of the URI where Okta will send OAuth responses"
   type        = string
-  default     = "/_logout"
+  default     = "/_logout2"
 }
 
 variable "session_duration" {

--- a/infra/terraform/modules/okta_native/variables.tf
+++ b/infra/terraform/modules/okta_native/variables.tf
@@ -35,6 +35,12 @@ variable "callback_path" {
   default     = "/_callback"
 }
 
+variable "logout_path" {
+  description = "The path of the URI where Okta will send OAuth responses"
+  type        = string
+  default     = "/_logout"
+}
+
 variable "session_duration" {
   description = "The number of hours that the JWT is valid for"
   type        = number

--- a/mocha/custom-config.json
+++ b/mocha/custom-config.json
@@ -19,6 +19,7 @@
     "SESSION_DURATION": 7200,
     "BASE_URL": "http://my-org.okta.com",
     "CALLBACK_PATH": "/_callback",
+    "LOGOUT_PATH": "/_logout",
     "PKCE_CODE_VERIFIER_LENGTH": "96",
     "AUTHZ": "OKTA"
 }

--- a/mocha/generic-config.json
+++ b/mocha/generic-config.json
@@ -19,6 +19,7 @@
     "SESSION_DURATION": "${session-duration}",
     "BASE_URL": "${base-url}",
     "CALLBACK_PATH": "${callback-path}",
+    "LOGOUT_PATH": "${logout-path}",
     "PKCE_CODE_VERIFIER_LENGTH": "${pkce-code-verifier-length}",
     "AUTHZ": "OKTA"
 }


### PR DESCRIPTION
This PR aims to make it easier for consumers to implement a logout that clears the cookies that are set by this module for authenticated users.

This module sets auth-related cookies as part of the callback from the auth provider: `TOKEN`, `CV` and `NONCE`, all of which should be cleared during a logout. In an effort not to bleed the domain from this module to other modules, I thought it would be good if this code had a route to handle it.

To achieve this, the PR adds a configurable logout route (defaults to `/_logout`) that will clear the auth cookies that might have been set by the application.