### PR TITLE
Configure NONCE and CV cookies as `secure` for pkce

### DIFF
--- a/authn/pkce.index.js
+++ b/authn/pkce.index.js
@@ -328,14 +328,16 @@ function redirect(request, headers, callback) {
           "key": "Set-Cookie",
           "value" : cookie.serialize('NONCE', n[1], {
             path: '/',
-            httpOnly: true
+            httpOnly: true,
+            secure: true
           })
         },
         {
           "key": "Set-Cookie",
           "value" : cookie.serialize('CV', challenge[0], {
             path: '/',
-            httpOnly: true
+            httpOnly: true,
+            secure: true
           })
         }
       ],


### PR DESCRIPTION
The PR is to resolve Issue #34 (Cookies created without Secure property set) for _pkce_; _github_ and _openai_ also need looking at.

Note: as stated on the issue, this could be considered a breaking change and therefore I'm happy to target a `v4` branch instead so major version release can be done.