### PR TITLE
include nodejs18.x in build targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Detailed instructions on testing your function can be found [in the Wiki](https:
 ## Build Requirements
 
 * [npm](https://www.npmjs.com/) ^7.20.0
-* [node](https://nodejs.org/en/) ^14.0
+* [node](https://nodejs.org/en/) ^18.0
 * [openssl](https://www.openssl.org)
 
 ## Building Generic Packages
@@ -179,7 +179,9 @@ The supported values of `package` are:
 * `okta_native` - builds a generic Lambda package for OKTA Native authentication
 * `rotate_key_pair` - builds a Lambda package for rotating the RSA keys in AWS Secrets Manager
 
-GitHub Actions automatically creates a new GitHub release when the repository owner pushes a tag that begins with `v`:
+GitHub Actions automatically creates a new GitHub release when the repository owner pushes a tag that begins with `v`.
+
+e.g.
 
 ```sh
 git tag -a -m "Target AWS Lambda Node.js 14.x runtime" v3.0.0

--- a/infra/terraform/modules/_lambda/main.tf
+++ b/infra/terraform/modules/_lambda/main.tf
@@ -20,7 +20,7 @@ resource "aws_lambda_function" "main" {
   role             = aws_iam_role.lambda.arn
   handler          = "index.handler"
   source_code_hash = base64sha256(var.package_url)
-  runtime          = "nodejs14.x"
+  runtime          = "nodejs18.x"
   timeout          = var.timeout
   publish          = var.lambda_at_edge
   tags             = var.tags

--- a/template.yaml
+++ b/template.yaml
@@ -8,7 +8,7 @@ Resources:
         Properties:
           CodeUri: distributions/{distribution_name}/{distribution_name}.zip
           Role: !GetAtt LambdaEdgeFunctionRole.Arn
-          Runtime: nodejs14.x
+          Runtime: nodejs18.x
           Handler: index.handler
           Timeout: 5
           AutoPublishAlias: LIVE


### PR DESCRIPTION
[Lambda@Edge supports nodejs 18.x as the most current nodejs version](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/edge-functions-restrictions.html#lambda-at-edge-restrictions-runtime) so I've included it in the build.

I've left nodejs 14.x and nodejs 16.x because they are also still supported by AWS (for now).