### PR TITLE
default runtime to nodejs16.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Detailed instructions on testing your function can be found [in the Wiki](https:
 ## Build Requirements
 
 * [npm](https://www.npmjs.com/) ^7.20.0
-* [node](https://nodejs.org/en/) ^18.0
+* [node](https://nodejs.org/en/) ^16.0
 * [openssl](https://www.openssl.org)
 
 ## Building Generic Packages

--- a/infra/terraform/modules/_lambda/main.tf
+++ b/infra/terraform/modules/_lambda/main.tf
@@ -20,7 +20,7 @@ resource "aws_lambda_function" "main" {
   role             = aws_iam_role.lambda.arn
   handler          = "index.handler"
   source_code_hash = base64sha256(var.package_url)
-  runtime          = "nodejs18.x"
+  runtime          = "nodejs16.x"
   timeout          = var.timeout
   publish          = var.lambda_at_edge
   tags             = var.tags

--- a/template.yaml
+++ b/template.yaml
@@ -8,7 +8,7 @@ Resources:
         Properties:
           CodeUri: distributions/{distribution_name}/{distribution_name}.zip
           Role: !GetAtt LambdaEdgeFunctionRole.Arn
-          Runtime: nodejs18.x
+          Runtime: nodejs16.x
           Handler: index.handler
           Timeout: 5
           AutoPublishAlias: LIVE


### PR DESCRIPTION
Whilst the app runs on nodejs18.x, the AWS SKD supplied is version 3.x and this app references version 2.x. A lambda layer can be supplied for this to work.

nodejs16.x comes bundled with v2.x of the AWS SDK, so no futher intervention is required; therefore I'm defaulting to nodejs16.x until we move the reference to v3 of the AWS SDK.