### PR TITLE
Set SameSite cookie attribute to Lax for CV and NONCE

### DIFF
--- a/authn/github.index.js
+++ b/authn/github.index.js
@@ -161,7 +161,12 @@ function redirect(request, headers, callback) {
       }],
       "set-cookie" : [{
         "key": "Set-Cookie",
-        "value" : cookie.serialize('TOKEN', '', { path: '/', expires: new Date(1970, 1, 1, 0, 0, 0, 0) })
+        "value" : cookie.serialize('TOKEN', '', {
+          path: '/',
+          expires: new Date(1970, 1, 1, 0, 0, 0, 0),
+          sameSite: 'strict',
+          secure: true
+        })
       }],
     },
   };
@@ -180,7 +185,12 @@ function unauthorized(body, callback) {
       }],
       "set-cookie" : [{
         "key": "Set-Cookie",
-        "value" : cookie.serialize('TOKEN', '', { path: '/', expires: new Date(1970, 1, 1, 0, 0, 0, 0) })
+        "value" : cookie.serialize('TOKEN', '', {
+          path: '/',
+          expires: new Date(1970, 1, 1, 0, 0, 0, 0),
+          sameSite: 'strict',
+          secure: true
+        })
       }],
     },
   };

--- a/authn/openid.index.js
+++ b/authn/openid.index.js
@@ -196,7 +196,9 @@ function mainProcess(event, context, callback) {
                         "key": "Set-Cookie",
                         "value" : cookie.serialize('NONCE', '', {
                           path: '/',
-                          expires: new Date(1970, 1, 1, 0, 0, 0, 0)
+                          expires: new Date(1970, 1, 1, 0, 0, 0, 0),
+                          sameSite: 'lax',
+                          secure: true
                         })
                       }
                     ],
@@ -240,21 +242,27 @@ function mainProcess(event, context, callback) {
             "key": "Set-Cookie",
             "value" : cookie.serialize('TOKEN', '', {
               path: '/',
-              expires: new Date(1970, 1, 1, 0, 0, 0, 0)
+              expires: new Date(1970, 1, 1, 0, 0, 0, 0),
+              sameSite: 'strict',
+              secure: true
             })
           },
           {
             "key": "Set-Cookie",
             "value" : cookie.serialize('CV', '', {
               path: '/',
-              expires: new Date(1970, 1, 1, 0, 0, 0, 0)
+              expires: new Date(1970, 1, 1, 0, 0, 0, 0),
+              sameSite: 'lax',
+              secure: true
             })
           },
           {
             "key": "Set-Cookie",
             "value" : cookie.serialize('NONCE', '', {
               path: '/',
-              expires: new Date(1970, 1, 1, 0, 0, 0, 0)
+              expires: new Date(1970, 1, 1, 0, 0, 0, 0),
+              sameSite: 'lax',
+              secure: true
             })
           }
         ],
@@ -318,7 +326,9 @@ function redirect(request, headers, callback) {
           "key": "Set-Cookie",
           "value" : cookie.serialize('TOKEN', '', {
             path: '/',
-            expires: new Date(1970, 1, 1, 0, 0, 0, 0)
+            expires: new Date(1970, 1, 1, 0, 0, 0, 0),
+            sameSite: 'strict',
+            secure: true
           })
         },
         {
@@ -326,7 +336,7 @@ function redirect(request, headers, callback) {
           "value" : cookie.serialize('NONCE', n[1], {
             path: '/',
             httpOnly: true,
-            sameSite: 'strict',
+            sameSite: 'lax',
             secure: true
           })
         }
@@ -370,14 +380,18 @@ function unauthorized(error, error_description, error_uri, callback) {
           "key": "Set-Cookie",
           "value" : cookie.serialize('TOKEN', '', {
             path: '/',
-            expires: new Date(1970, 1, 1, 0, 0, 0, 0)
+            expires: new Date(1970, 1, 1, 0, 0, 0, 0),
+            sameSite: 'strict',
+            secure: true
           })
         },
         {
           "key": "Set-Cookie",
           "value" : cookie.serialize('NONCE', '', {
             path: '/',
-            expires: new Date(1970, 1, 1, 0, 0, 0, 0)
+            expires: new Date(1970, 1, 1, 0, 0, 0, 0),
+            sameSite: 'lax',
+            secure: true
           })
         }
       ],

--- a/authn/pkce.index.js
+++ b/authn/pkce.index.js
@@ -195,7 +195,9 @@ function mainProcess(event, context, callback) {
                         "key": "Set-Cookie",
                         "value" : cookie.serialize('NONCE', '', {
                           path: '/',
-                          expires: new Date(1970, 1, 1, 0, 0, 0, 0)
+                          expires: new Date(1970, 1, 1, 0, 0, 0, 0),
+                          sameSite: 'lax',
+                          secure: true
                         })
                       }
                     ],
@@ -239,21 +241,27 @@ function mainProcess(event, context, callback) {
             "key": "Set-Cookie",
             "value" : cookie.serialize('TOKEN', '', {
               path: '/',
-              expires: new Date(1970, 1, 1, 0, 0, 0, 0)
+              expires: new Date(1970, 1, 1, 0, 0, 0, 0),
+              sameSite: 'strict',
+              secure: true
             })
           },
           {
             "key": "Set-Cookie",
             "value" : cookie.serialize('CV', '', {
               path: '/',
-              expires: new Date(1970, 1, 1, 0, 0, 0, 0)
+              expires: new Date(1970, 1, 1, 0, 0, 0, 0),
+              sameSite: 'lax',
+              secure: true
             })
           },
           {
             "key": "Set-Cookie",
             "value" : cookie.serialize('NONCE', '', {
               path: '/',
-              expires: new Date(1970, 1, 1, 0, 0, 0, 0)
+              expires: new Date(1970, 1, 1, 0, 0, 0, 0),
+              sameSite: 'lax',
+              secure: true
             })
           }
         ],
@@ -332,7 +340,9 @@ function redirect(request, headers, callback) {
           "key": "Set-Cookie",
           "value" : cookie.serialize('TOKEN', '', {
             path: '/',
-            expires: new Date(1970, 1, 1, 0, 0, 0, 0)
+            expires: new Date(1970, 1, 1, 0, 0, 0, 0),
+            sameSite: 'strict',
+            secure: true
           })
         },
         {
@@ -340,7 +350,7 @@ function redirect(request, headers, callback) {
           "value" : cookie.serialize('NONCE', n[1], {
             path: '/',
             httpOnly: true,
-            sameSite: 'strict',
+            sameSite: 'lax',
             secure: true
           })
         },
@@ -349,7 +359,7 @@ function redirect(request, headers, callback) {
           "value" : cookie.serialize('CV', challenge[0], {
             path: '/',
             httpOnly: true,
-            sameSite: 'strict',
+            sameSite: 'lax',
             secure: true
           })
         }
@@ -394,14 +404,18 @@ function unauthorized(error, error_description, error_uri, callback) {
           "key": "Set-Cookie",
           "value" : cookie.serialize('TOKEN', '', {
             path: '/',
-            expires: new Date(1970, 1, 1, 0, 0, 0, 0)
+            expires: new Date(1970, 1, 1, 0, 0, 0, 0),
+            sameSite: 'strict',
+            secure: true
           })
         },
         {
           "key": "Set-Cookie",
           "value" : cookie.serialize('NONCE', '', {
             path: '/',
-            expires: new Date(1970, 1, 1, 0, 0, 0, 0)
+            expires: new Date(1970, 1, 1, 0, 0, 0, 0),
+            sameSite: 'lax',
+            secure: true
           })
         }
       ],


### PR DESCRIPTION
This change re-enables the ability to have authentication that isn't embedded into the same site.
e.g. changing host to Okta to log in, then back to site once authenticated.

The feature was removed in security bump to version 4, but is required by one of our uses of this module.

_Note:_ this PR also sets the `SameSite` and `Secure` cookie attributes when removing (expiring) the cookies to the same values as when it was set to conform with browser implementations from the [Incrementally Better Cookies](https://datatracker.ietf.org/doc/html/draft-west-cookie-incrementalism-00/#section-3.2) that's now required for all values: `Strict`, `Lax` and `None`.