### PR TITLE
fix: stop redirect loop caused by TOKEN cookie not sent

### DIFF
--- a/authn/github.index.js
+++ b/authn/github.index.js
@@ -87,7 +87,7 @@ function mainProcess(event, context, callback) {
                               } // Options
                             ),
                             {
-                              sameSite: 'strict',
+                              sameSite: 'lax',
                               secure: true
                             }
                           )
@@ -164,7 +164,7 @@ function redirect(request, headers, callback) {
         "value" : cookie.serialize('TOKEN', '', {
           path: '/',
           expires: new Date(1970, 1, 1, 0, 0, 0, 0),
-          sameSite: 'strict',
+          sameSite: 'lax',
           secure: true
         })
       }],
@@ -188,7 +188,7 @@ function unauthorized(body, callback) {
         "value" : cookie.serialize('TOKEN', '', {
           path: '/',
           expires: new Date(1970, 1, 1, 0, 0, 0, 0),
-          sameSite: 'strict',
+          sameSite: 'lax',
           secure: true
         })
       }],

--- a/authn/openid.index.js
+++ b/authn/openid.index.js
@@ -188,7 +188,7 @@ function mainProcess(event, context, callback) {
                         ), {
                           path: '/',
                           maxAge: config.SESSION_DURATION,
-                          sameSite: 'strict',
+                          sameSite: 'lax',
                           secure: true
                         })
                       },
@@ -243,7 +243,7 @@ function mainProcess(event, context, callback) {
             "value" : cookie.serialize('TOKEN', '', {
               path: '/',
               expires: new Date(1970, 1, 1, 0, 0, 0, 0),
-              sameSite: 'strict',
+              sameSite: 'lax',
               secure: true
             })
           },
@@ -327,7 +327,7 @@ function redirect(request, headers, callback) {
           "value" : cookie.serialize('TOKEN', '', {
             path: '/',
             expires: new Date(1970, 1, 1, 0, 0, 0, 0),
-            sameSite: 'strict',
+            sameSite: 'lax',
             secure: true
           })
         },
@@ -381,7 +381,7 @@ function unauthorized(error, error_description, error_uri, callback) {
           "value" : cookie.serialize('TOKEN', '', {
             path: '/',
             expires: new Date(1970, 1, 1, 0, 0, 0, 0),
-            sameSite: 'strict',
+            sameSite: 'lax',
             secure: true
           })
         },

--- a/authn/pkce.index.js
+++ b/authn/pkce.index.js
@@ -187,7 +187,7 @@ function mainProcess(event, context, callback) {
                           path: '/',
                           httpOnly: true,
                           secure: true,
-                          sameSite: 'strict',
+                          sameSite: 'lax',
                           maxAge: parseInt(config.SESSION_DURATION)
                         })
                       },
@@ -242,7 +242,7 @@ function mainProcess(event, context, callback) {
             "value" : cookie.serialize('TOKEN', '', {
               path: '/',
               expires: new Date(1970, 1, 1, 0, 0, 0, 0),
-              sameSite: 'strict',
+              sameSite: 'lax',
               secure: true
             })
           },
@@ -341,7 +341,7 @@ function redirect(request, headers, callback) {
           "value" : cookie.serialize('TOKEN', '', {
             path: '/',
             expires: new Date(1970, 1, 1, 0, 0, 0, 0),
-            sameSite: 'strict',
+            sameSite: 'lax',
             secure: true
           })
         },
@@ -405,7 +405,7 @@ function unauthorized(error, error_description, error_uri, callback) {
           "value" : cookie.serialize('TOKEN', '', {
             path: '/',
             expires: new Date(1970, 1, 1, 0, 0, 0, 0),
-            sameSite: 'strict',
+            sameSite: 'lax',
             secure: true
           })
         },


### PR DESCRIPTION
While the previous change works when authenticating on an external site and then browsing to the site using this module. Redirecting to the site using this module from the authentication site does not work and ends in a 302 redirect loop.

This is caused by the `TOKEN` cookie having `SameSite` set to `Strict`. The browser does not count the `/callback?...` 302 redirect to `/` as the same site and therefore does not send the `TOKEN` cookie.

I've updated the `SameSite` to `Lax` for the `TOKEN` cookie so that it will be sent on the redirect.