### PR TITLE
update to nodejs20.x runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [20.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Use Node.js 14
+      - name: Use Node.js 20
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '20'
 
       - name: Run tests
         run: npm run-script test-ci

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Detailed instructions on testing your function can be found [in the Wiki](https:
 ## Build Requirements
 
 * [npm](https://www.npmjs.com/) ^7.20.0
-* [node](https://nodejs.org/en/) ^16.0
+* [node](https://nodejs.org/en/) ^20.0
 * [openssl](https://www.openssl.org)
 
 ## Building Generic Packages

--- a/infra/terraform/modules/_lambda/main.tf
+++ b/infra/terraform/modules/_lambda/main.tf
@@ -20,7 +20,7 @@ resource "aws_lambda_function" "main" {
   role             = aws_iam_role.lambda.arn
   handler          = "index.handler"
   source_code_hash = base64sha256(var.package_url)
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs20.x"
   timeout          = var.timeout
   publish          = var.lambda_at_edge
   tags             = var.tags

--- a/template.yaml
+++ b/template.yaml
@@ -8,7 +8,7 @@ Resources:
         Properties:
           CodeUri: distributions/{distribution_name}/{distribution_name}.zip
           Role: !GetAtt LambdaEdgeFunctionRole.Arn
-          Runtime: nodejs16.x
+          Runtime: nodejs20.x
           Handler: index.handler
           Timeout: 5
           AutoPublishAlias: LIVE


### PR DESCRIPTION
To address the issue of the current runtime (`nodejs14.x`) no longer being supported this PR aims to update the deployment to use the latest supported runtime, `nodejs20.x`

Ref issue #49 