### PR TITLE
use iress specific action runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: push
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: grouptech-actions-runners
 
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Upload Release Assets
-    runs-on: ubuntu-latest
+    runs-on: grouptech-actions-runners
     steps:
 
       - name: Checkout code


### PR DESCRIPTION
Iress uses [larger runners](https://docs.github.com/en/enterprise-cloud@latest/actions/using-github-hosted-runners/about-larger-runners/about-larger-runners) to run Github actions. This is due to an inability to use regular GitHub hosted runners in conjunction with our GitHub IP allow list.  Larger runners can be assigned static IP addresses that are whitelisted in both GitHub and Artifactory. 